### PR TITLE
Rename Mongo URI variable for clarity and standardization.

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -15,11 +15,11 @@ switch (process.env.NODE_ENV) {
     throw new Error(`'NODE_ENV' ${process.env.NODE_ENV} is not handled!`);
 }
 
-const ATLAS_URI = process.env.ATLAS_URI || '';
+const DATABASE_URI = process.env.DATABASE_URI || '';
 const JWT_SECRET = process.env.JWT_SECRET || '';
 
 // sendgrid configs
 const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY || '';
 const SENDGRID_EMAIL = 'hello@email.com';
 
-export { ATLAS_URI, JWT_SECRET, SENDGRID_API_KEY, SENDGRID_EMAIL };
+export { DATABASE_URI, JWT_SECRET, SENDGRID_API_KEY, SENDGRID_EMAIL };

--- a/src/utils/mongo.ts
+++ b/src/utils/mongo.ts
@@ -1,11 +1,11 @@
 import mongoose from 'mongoose';
-import { ATLAS_URI } from './config';
+import { DATABASE_URI } from './config';
 
 export default function connectToDatabase(
   cb: (err: Error) => void
 ): (err: Error) => void {
   mongoose.Promise = global.Promise;
-  mongoose.connect(ATLAS_URI, {
+  mongoose.connect(DATABASE_URI, {
     useNewUrlParser: true,
     useCreateIndex: true,
     useUnifiedTopology: true,


### PR DESCRIPTION
It's much more common for people to look for a DATABASE_URI when
starting up a project. In addition, ATLAS_URI is really specific to a
commercial product offered by the company behind MongoDB, which we
aren't actually using, which is confusing.