### PR TITLE
Remove dotenv as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "chart.js": "^2.9.4",
     "cors": "^2.8.5",
     "cpx": "^1.5.0",
-    "dotenv": "^8.2.0",
     "emoji-mart": "^3.0.0",
     "express": "^4.17.1",
     "express-status-monitor": "^1.3.3",

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,20 +1,3 @@
-import { config as configDotenv } from 'dotenv';
-import { resolve } from 'path';
-
-switch (process.env.NODE_ENV) {
-  case 'development':
-    console.log("Environment is 'development'");
-    configDotenv({
-      path: resolve(__dirname, '../../.env.development'),
-    });
-    break;
-  case 'production':
-    console.log("Environment is 'production'");
-    break;
-  default:
-    throw new Error(`'NODE_ENV' ${process.env.NODE_ENV} is not handled!`);
-}
-
 const DATABASE_URI = process.env.DATABASE_URI || '';
 const JWT_SECRET = process.env.JWT_SECRET || '';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1523,11 +1523,6 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dotenv@^8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
-  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
-
 duplexer@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"


### PR DESCRIPTION
dotenv is not really the right solution to our configuration needs since Aptible has its own system for sharing env variables with the building and running containers. The project already only used it for development, so no reason the have it as a dependency when people can just use their own local solution for managing env variables per directory. I highly recommend direnv 😉 

This builds on top of #7 , so once that's merged I'll rebase this PR to contain the single dotenv related commit. 
