### PR TITLE
Setup project for deployment on Aptible

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+build
+.envrc
+.env
+.aptible.env

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ typings/
 # TypeScript cache
 *.tsbuildinfo
 
+#typscript compiled output
+build/
+
 # Optional npm cache directory
 .npm
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:12.20
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY package.json /app/package.json
+COPY yarn.lock /app/yarn.lock
+
+RUN yarn install --frozen-lockfile
+
+COPY . /app
+
+ENV NODE_ENV=production
+
+EXPOSE 3000
+CMD ["yarn", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,7 @@ COPY . /app
 
 ENV NODE_ENV=production
 
+RUN yarn build
+
 EXPOSE 3000
-CMD ["yarn", "start"]
+CMD ["node", "build/index.js"]

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web:ts-node/src/index.ts

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint '*/**/*.{js,ts,tsx}' --quiet --fix",
     "server": "ts-node-dev --respawn src/index.ts",
-    "start": "ts-node ./src/index.ts",
+    "start": "ts-node src/index.ts",
     "build": "tsc"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ connectToDatabase((err) => {
   if (err) console.log(err);
 });
 
-app.set('port', process.env.PORT || 5000);
+app.set('port', process.env.PORT || 3000);
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(cors());

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    // "outDir": "./build",
+    "outDir": "./build",
     /* Redirect output structure to the directory. */
     // "rootDir": "./" /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */,
     // "composite": true,                     /* Enable project compilation */


### PR DESCRIPTION
1. Puts basic Dockerfile in place, that's designed to build the project and run the compiled JS in a way Aptible expects. 

1. Adjusts TypeScript output configuration so compiled typescript outputs to `build` directory where it can be run directly by `node` rather than `ts-node`

1. Changes default express/node setup to expose port 3000 for consistency of containers on Aptible. 
    * If you run into problems locally you can choose your own port using `PORT=5111 yarn server` 

1. Cleans up an old Procfile that isn't relevant on Aptible, but was hold over from hacky heroku deploy in the past. 

### Note

I actually have this successfully running on Aptible using some pushing of my branch to aptible master. 