### PR TITLE
Standardize Twilio config parsing from ENV variables

### DIFF
--- a/src/routes/twilio.api.ts
+++ b/src/routes/twilio.api.ts
@@ -19,14 +19,6 @@ import auth from '../middleware/auth';
 
 const {MessagingResponse} = require('twilio').twiml;
 
-let twilioNumber: string;
-if (TWILIO_FROM_NUMBER) {
-  twilioNumber = TWILIO_FROM_NUMBER.replace(/[^0-9.]/g, '');
-} else {
-  twilioNumber = 'MISSING';
-  console.log('No phone number found in env vars!');
-}
-
 const twilio = require('twilio')(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN);
 const bodyParser = require('body-parser');
 
@@ -82,13 +74,13 @@ router.post('/sendMessage', auth, function (req, res) {
   twilio.messages
     .create({
       body: contnet,
-      from: twilioNumber, // this is hardcoded right now
+      from: TWILIO_FROM_NUMBER,
       to: recept
     });
 
   const outgoingMessage = new Message({
     sent: true,
-    phoneNumber: twilioNumber,
+    phoneNumber: TWILIO_FROM_NUMBER,
     patientID,
     message: contnet,
     sender: 'COACH',

--- a/src/routes/twilio.api.ts
+++ b/src/routes/twilio.api.ts
@@ -10,7 +10,7 @@ import {
 
 import { Message } from '../models/message.model';
 import { MessageTemplate } from '../models/messageTemplate.model';
-import {TWILIO_ACCOUNT_SID, TWILIO_AUTHTOKEN, TWILIO_NUMBER} from '../utils/config';
+import {TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER} from '../utils/config';
 
 import { Outcome } from '../models/outcome.model';
 import { Patient } from '../models/patient.model';
@@ -20,14 +20,14 @@ import auth from '../middleware/auth';
 const {MessagingResponse} = require('twilio').twiml;
 
 let twilioNumber: string;
-if (TWILIO_NUMBER) {
-  twilioNumber = TWILIO_NUMBER.replace(/[^0-9.]/g, '');
+if (TWILIO_FROM_NUMBER) {
+  twilioNumber = TWILIO_FROM_NUMBER.replace(/[^0-9.]/g, '');
 } else {
   twilioNumber = 'MISSING';
   console.log('No phone number found in env vars!');
 }
 
-const twilio = require('twilio')(TWILIO_ACCOUNT_SID, TWILIO_AUTHTOKEN);
+const twilio = require('twilio')(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN);
 const bodyParser = require('body-parser');
 
 const router = express.Router();

--- a/src/routes/twilio.api.ts
+++ b/src/routes/twilio.api.ts
@@ -65,7 +65,7 @@ function initializeState() {
 
 initializeState();
 
-router.post('/sendMessage', auth, function (req, res) {
+router.post('/sendMessage', auth, (req, res) => {
   const contnet = req.body.message;
   const recept = req.body.to;
   const patientID = new ObjectId(req.body.patientID);
@@ -97,7 +97,7 @@ router.post('/sendMessage', auth, function (req, res) {
 
 
 // this route receives and parses the message from one user, then responds accordingly with the appropriate output
-router.post('/reply', function (req, res) {
+router.post('/reply', (req, res) => {
   const twiml = new MessagingResponse();
   const message = twiml.message();
   let response = req.body.Body;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -5,7 +5,4 @@ export const JWT_SECRET = process.env.JWT_SECRET || '';
 export const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY || '';
 export const SENDGRID_EMAIL = 'hello@email.com';
 
-export const {TWILIO_ACCOUNT_SID} = process.env;
-export const TWILIO_AUTHTOKEN = process.env.TWILIO_AUTH_TOKEN;
-export const TWILIO_NUMBER = process.env.TWILIO_PHONE_NUMBER;
-
+export const {TWILIO_ACCOUNT_SID, TWILIO_FROM_NUMBER, TWILIO_AUTH_TOKEN} = process.env;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -5,4 +5,14 @@ export const JWT_SECRET = process.env.JWT_SECRET || '';
 export const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY || '';
 export const SENDGRID_EMAIL = 'hello@email.com';
 
-export const {TWILIO_ACCOUNT_SID, TWILIO_FROM_NUMBER, TWILIO_AUTH_TOKEN} = process.env;
+
+const parseTwilioFromNumber = () => {
+  if (!process.env.TWILIO_FROM_NUMBER) {
+    throw new Error('No TWILIO_FROM_NUMBER Found can not run server');
+  }
+  return process.env.TWILIO_FROM_NUMBER.replace(/[^0-9.]/g, '');
+};
+
+export const {TWILIO_ACCOUNT_SID,  TWILIO_AUTH_TOKEN} = process.env;
+
+export const TWILIO_FROM_NUMBER = parseTwilioFromNumber();

--- a/src/utils/scheduling.ts
+++ b/src/utils/scheduling.ts
@@ -6,14 +6,6 @@ import { Patient } from '../models/patient.model';
 
 const twilio = require('twilio')(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN);
 
-let twilioNumber: string;
-if (TWILIO_FROM_NUMBER) {
-  twilioNumber = TWILIO_FROM_NUMBER.replace(/[^0-9.]/g, '');
-} else {
-  twilioNumber = 'MISSING';
-  console.log('No phone number found in env vars!');
-}
-
 
 // time in seconds between each run of scheduler
 const schedulingInterval = 5;
@@ -34,7 +26,7 @@ const sendMessage = (msg : IMessage) => {
   twilio.messages
     .create({
       body: msg.message,
-      from: twilioNumber,
+      from: TWILIO_FROM_NUMBER,
       to: msg.phoneNumber
     });
 

--- a/src/utils/scheduling.ts
+++ b/src/utils/scheduling.ts
@@ -1,14 +1,14 @@
 import schedule from 'node-schedule';
 import { ObjectId } from 'mongodb';
 import { Message, IMessage } from '../models/message.model';
-import {TWILIO_ACCOUNT_SID, TWILIO_AUTHTOKEN, TWILIO_NUMBER} from './config';
+import {TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER} from './config';
 import { Patient } from '../models/patient.model';
 
-const twilio = require('twilio')(TWILIO_ACCOUNT_SID, TWILIO_AUTHTOKEN);
+const twilio = require('twilio')(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN);
 
 let twilioNumber: string;
-if (TWILIO_NUMBER) {
-  twilioNumber = TWILIO_NUMBER.replace(/[^0-9.]/g, '');
+if (TWILIO_FROM_NUMBER) {
+  twilioNumber = TWILIO_FROM_NUMBER.replace(/[^0-9.]/g, '');
 } else {
   twilioNumber = 'MISSING';
   console.log('No phone number found in env vars!');


### PR DESCRIPTION
1. Have all the project specific config names match the actual name of the ENV variable they come from. 
2. Move all the weird Twilio phone number parsing logic into 1 place. 