### PR TITLE
Fix type compilation issue that arises with yarn start

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -2,10 +2,11 @@ import * as express from 'express';
 import { verify } from 'jsonwebtoken';
 import { IUser } from '../models/user.model';
 import errorHandler from '../routes/error';
+import { CoachMeRequest } from '../types/coach_me_request';
 import { JWT_SECRET } from '../utils/config';
 
 const auth = (
-  req: express.Request,
+  req: CoachMeRequest,
   res: express.Response,
   next: express.NextFunction
 ) => {

--- a/src/routes/coach.auth.ts
+++ b/src/routes/coach.auth.ts
@@ -10,6 +10,7 @@ import {
   validateRefreshToken,
 } from './coach.util';
 import { Patient } from '../models/patient.model';
+import { CoachMeRequest } from '../types/coach_me_request';
 
 
 const router = express.Router();
@@ -108,7 +109,7 @@ router.post('/refreshToken', (req, res) => {
 
 // get me
 // protected route
-router.get('/me', auth, (req, res) => {
+router.get('/me', auth, (req: CoachMeRequest, res) => {
 
   const { userId } = req;
   return Coach.findById(new ObjectId(userId))

--- a/src/types/coach_me_request.ts
+++ b/src/types/coach_me_request.ts
@@ -1,0 +1,5 @@
+import express from 'express';
+
+export type CoachMeRequest = express.Request & {
+  userId?: string;
+};


### PR DESCRIPTION
Probably worth figuring out why this wasn't caught by a normal yarn
build, but when you run yarn start a type error comes up because of our
auth middleware.

This adds the necessary extra typing work to address the issue