### PR TITLE
Automated daily message should ignore case in patient or template

### DIFF
--- a/src/routes/messages.api.ts
+++ b/src/routes/messages.api.ts
@@ -26,7 +26,9 @@ cron.schedule(
           patients.forEach((patient) => {
             if (patient.enabled) {
               const messages = MessageTemplates.filter(
-                (template) => template.language === patient.language,
+                (template) =>
+                  template.language.toLowerCase() ===
+                  patient.language.toLowerCase(),
               );
               if (messages.length < 1) {
                 console.log(


### PR DESCRIPTION
Spanish wasn't working on staging because the messageTemplate language
was uppercase, but the patients language was lowercase