### PR TITLE
Do not allow multiple patients with same phone number to be created

### DIFF
--- a/src/models/patient.model.ts
+++ b/src/models/patient.model.ts
@@ -43,4 +43,10 @@ const PatientSchema = new Schema({
 
 const Patient = mongoose.model<IPatient>('Patient', PatientSchema);
 
-export { Patient, IPatient };
+const PatientForPhoneNumber = async (
+  phoneNumber: string,
+): Promise<IPatient | null> => {
+  return Patient.findOne({ phoneNumber });
+};
+
+export { Patient, PatientForPhoneNumber, IPatient };

--- a/src/routes/patient.api.ts
+++ b/src/routes/patient.api.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/indent */
 import express from 'express';
 import { Outcome } from '../models/outcome.model';
-import { Patient } from '../models/patient.model';
+import { Patient, PatientForPhoneNumber } from '../models/patient.model';
 import auth from '../middleware/auth';
 import errorHandler from './error';
 import { Message } from '../models/message.model';
@@ -19,6 +19,13 @@ router.post('/add', auth, async (req, res) => {
   ) {
     return res.status(400).json({
       msg: 'Unable to add patient: invalid phone number',
+    });
+  }
+
+  if (await PatientForPhoneNumber(req.body.phoneNumber)) {
+    return res.status(400).json({
+      msg:
+        'Unable to add patient: patient already exists for given phone number',
     });
   }
 


### PR DESCRIPTION
Now that we have this helper function `PatientForPhoneNumber` we should be able to refactor a couple of other places that lookup patients by phone numbers to this 1 shared function. 

Thought that was out of scope for this change though, so kept it just to this. 

https://trello.com/c/H1EUHwz8/49-adding-a-new-patient-to-the-system-should-not-be-allowed-if-we-already-have-a-patient-record-with-the-same-phone-number