### PR TITLE
Force all requests in production to come over SSL

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import messageRouter from './routes/messages.api';
 import coachRouter from './routes/coach.auth';
 import twilioRouter from './routes/twilio.api';
 import messageTemplateRouter from './routes/messageTemplate.api';
+import RequireHttps from './middleware/require_https';
 
 const app = express();
 
@@ -22,6 +23,7 @@ app.set('port', process.env.PORT || 3000);
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(cors());
+app.use(RequireHttps);
 
 // API Routes
 app.use('/api/patients', patientRouter);

--- a/src/middleware/require_https.ts
+++ b/src/middleware/require_https.ts
@@ -1,0 +1,17 @@
+import * as express from 'express';
+import { CoachMeRequest } from '../types/coach_me_request';
+
+export default (
+  req: CoachMeRequest,
+  res: express.Response,
+  next: express.NextFunction,
+) => {
+  if (
+    !req.secure &&
+    req.get('x-forwarded-proto') !== 'https' &&
+    process.env.NODE_ENV !== 'development'
+  ) {
+    return res.redirect(`https://${req.get('host')}${req.url}`);
+  }
+  return next();
+};


### PR DESCRIPTION
- Any request that is not SSL will be redirected to secure channel.
- Ultimately this doesn't provide complete protection because a hacker
can still steal cookies, etc from the non secure request. However, I've
found this tends to make JS frontend codebases go boom during testing on
staging which helps catch insecure requests on staging.