### PR TITLE
Text box for creating a new message from coach -> patient is not visible

### DIFF
--- a/src/routes/patient.api.ts
+++ b/src/routes/patient.api.ts
@@ -161,7 +161,7 @@ router.get('/getPatientOutcomes/:patientID', auth, (req, res) => {
   const id = req.params.patientID;
   return Outcome.find({ patientID: new ObjectId(id) })
     .then((outcomeList) => {
-      if (!outcomeList || outcomeList.length === 0)
+      if (!outcomeList)
         return errorHandler(res, 'No outcomes found!');
 
       return res
@@ -185,7 +185,7 @@ router.get('/getPatientMessages/:patientID', auth, (req, res) => {
   const id = req.params.patientID;
   return Message.find({ patientID: new ObjectId(id) })
     .then((outcomeList) => {
-      if (!outcomeList || outcomeList.length === 0)
+      if (!outcomeList)
         return errorHandler(res, 'No outcomes found!');
       return res.status(200).json(outcomeList);
     })


### PR DESCRIPTION
Removed 400 returned for patient messages and outcomes, returns empt list like frontend expects.
