### PR TITLE
separated non-auth related endpoints into new file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,8 @@ import './utils/config';
 
 import patientRouter from './routes/patient.api';
 import messageRouter from './routes/messages/messages.api';
-import coachRouter from './routes/coach.auth';
+import coachAuthRouter from './routes/coach.auth';
+import coachApiRouter from './routes/coach.api';
 import twilioRouter from './routes/twilio/twilio.api';
 import messageTemplateRouter from './routes/messageTemplate.api';
 import RequireHttps from './middleware/require_https';
@@ -26,7 +27,8 @@ app.use(RequireHttps);
 
 // API Routes
 app.use('/api/patients', patientRouter);
-app.use('/api/coaches', coachRouter);
+app.use('/api/coaches', coachAuthRouter);
+app.use('/api/coaches', coachApiRouter);
 app.use('/api/messages', messageRouter);
 app.use('/api/twilio', twilioRouter);
 app.use('/api/messageTemplate', messageTemplateRouter);

--- a/src/routes/coach.api.ts
+++ b/src/routes/coach.api.ts
@@ -1,0 +1,33 @@
+import express from 'express';
+import { Coach } from '../models/coach.model';
+import auth from '../middleware/auth';
+import { Patient } from '../models/patient.model';
+
+const router = express.Router();
+
+router.get('/getPatients', auth, (req, res) => {
+  return Patient.find().then((patients) => {
+    return res.status(200).json(patients);
+  });
+});
+
+router.get('/search', auth, async (req, res) => {
+  const { query } = req.query;
+  Coach.aggregate([
+    { $project: { name: { $concat: ['$firstName', ' ', '$lastName'] } } },
+    {
+      $match: {
+        name: {
+          $regex: query,
+          $options: 'i',
+        },
+      },
+    },
+  ]).exec((err, result) => {
+    return res.status(200).json({
+      coaches: result,
+    });
+  });
+});
+
+export default router;

--- a/src/routes/coach.auth.ts
+++ b/src/routes/coach.auth.ts
@@ -9,7 +9,6 @@ import {
   generateRefreshToken,
   validateRefreshToken,
 } from './coach.util';
-import { Patient } from '../models/patient.model';
 import { CoachMeRequest } from '../types/coach_me_request';
 
 const router = express.Router();
@@ -105,31 +104,6 @@ router.get('/me', auth, (req: CoachMeRequest, res) => {
       return res.status(200).json({ success: true, data: coach });
     })
     .catch((err) => errorHandler(res, err.message));
-});
-
-router.get('/getPatients', auth, (req, res) => {
-  return Patient.find().then((patients) => {
-    return res.status(200).json(patients);
-  });
-});
-
-router.get('/search', auth, async (req, res) => {
-  const { query } = req.query;
-  Coach.aggregate([
-    { $project: { name: { $concat: ['$firstName', ' ', '$lastName'] } } },
-    {
-      $match: {
-        name: {
-          $regex: query,
-          $options: 'i',
-        },
-      },
-    },
-  ]).exec((err, result) => {
-    return res.status(200).json({
-      coaches: result,
-    });
-  });
 });
 
 export default router;


### PR DESCRIPTION
The endpoints still have the same path for now. We could give them distinct paths but I wasn't sure which direction you'd want to go with that.