### PR TITLE
Fix BG weekly outcome report not being sent.

### DIFF
--- a/src/background_jobs/utils.ts
+++ b/src/background_jobs/utils.ts
@@ -272,20 +272,29 @@ const sendOutcomesToPatients = async () => {
   });
 };
 
+export const getDateRelativeToMonday = (offset: number) => {
+  const lastMonday = new Date();
+  lastMonday.setDate(lastMonday.getDate() - ((lastMonday.getDay() + 6) % 7));
+  lastMonday.setDate(lastMonday.getDate() + offset);
+  return lastMonday;
+};
+
 export const weeklyReport = async () => {
   const schedules = await Schedule.findOne({});
   const lastMonday = new Date();
+  const today = new Date();
   lastMonday.setDate(lastMonday.getDate() - ((lastMonday.getDay() + 6) % 7));
   if (!schedules) {
-    const newSchedule = new Schedule({ weeklyReport: lastMonday });
+    const newSchedule = new Schedule({
+      weeklyReport: getDateRelativeToMonday(-7),
+    });
     await newSchedule.save();
     weeklyReport();
   }
   if (schedules) {
-    const dateDifference =
-      lastMonday.getDate() - schedules.weeklyReport.getDate();
-    if (dateDifference > 0) {
-      await Schedule.findOneAndUpdate({}, { weeklyReport: new Date() });
+    const dateDifference = today.getTime() - schedules.weeklyReport.getTime();
+    if (dateDifference > 6.5 * 24 * 3600 * 1000) {
+      await Schedule.findOneAndUpdate({}, { weeklyReport: lastMonday });
       sendOutcomesToPatients();
     }
   }


### PR DESCRIPTION
Problem
 - BG weekly reports are not being sent.
 
Source:
- When the weeklyReport function checks for time difference, it uses GetDate(), and it checks if it's a new week. The issue is that GetDate() returns day of month so the code was checking if the day of this Monday was higher than the day of last Monday (July 5 vs June 28).  But the code only used the 5 and 28.
So because 28 > 5, the messages are never sent.

Fix:
- Instead of using getDate(), use GetTime(), that way the time is 'linear' and the month check will work.
