### PR TITLE
Add general number to patient api

### DIFF
--- a/src/routes/patient.api.ts
+++ b/src/routes/patient.api.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/indent */
 import express from 'express';
 import { Outcome } from '../models/outcome.model';
 import { Patient, PatientForPhoneNumber } from '../models/patient.model';
@@ -164,14 +163,18 @@ router.get('/getPatient/:patientID', auth, (req, res) => {
     .catch((err) => errorHandler(res, err.message));
 });
 
-router.get('/getPatientMessages/:patientID', auth, (req, res) => {
+router.get('/getPatientMessages/:patientID', auth, async (req, res) => {
   const id = req.params.patientID;
-  return Message.find({ patientID: new ObjectId(id) })
-    .then((outcomeList) => {
-      if (!outcomeList) return errorHandler(res, 'No outcomes found!');
-      return res.status(200).json(outcomeList);
-    })
-    .catch((err) => errorHandler(res, err.message));
+  const messages = await Message.find({
+    patientID: new ObjectId(id),
+    sent: true,
+    isCoachingMessage: true,
+  });
+
+  if (!messages) {
+    return errorHandler(res, 'No messages found!');
+  }
+  return res.status(200).json(messages);
 });
 
 router.post('/status', auth, (req, res) => {

--- a/src/routes/patient.integration.test.ts
+++ b/src/routes/patient.integration.test.ts
@@ -1,0 +1,77 @@
+import request from 'supertest';
+import express from 'express';
+import {
+  connectDatabase,
+  closeDatabase,
+  clearDatabase,
+  getTestToken,
+  createPatient,
+} from '../../test/db';
+import { Patient } from '../models/patient.model';
+import { Message } from '../models/message.model';
+import patientRouter from './patient.api';
+
+const patientApp = express();
+
+patientApp.use(express.urlencoded({ extended: false }));
+patientApp.use('/', patientRouter);
+
+if (process.env.NODE_ENV === 'development') {
+  const tokenObject = { token: [] };
+  beforeAll(async (done: any) => {
+    await connectDatabase();
+    await getTestToken(tokenObject, done);
+  });
+  beforeEach(async () => clearDatabase());
+  afterAll(() => closeDatabase());
+
+  describe('Patient api routes work as intended', () => {
+    it('getPatientMessages/:patientID route gets coaching messages only', async () => {
+      await createPatient('1114446668');
+      const patient = await Patient.findOne();
+      const newMessage = new Message({
+        phoneNumber: patient?.phoneNumber,
+        patientID: patient?._id,
+        sender: 'COACH',
+        message: 'Example smg',
+        date: new Date(),
+        sent: true,
+        isCoachingMessage: true,
+      });
+      await newMessage.save();
+      const newMessageNotShow = new Message({
+        phoneNumber: patient?.phoneNumber,
+        patientID: patient?._id,
+        sender: 'COACH',
+        message: 'Example smg',
+        date: new Date(),
+        sent: false,
+        isCoachingMessage: true,
+      });
+      await newMessageNotShow.save();
+      const newMessageNotShow2 = new Message({
+        phoneNumber: patient?.phoneNumber,
+        patientID: patient?._id,
+        sender: 'COACH',
+        message: 'Example smg',
+        date: new Date(),
+        sent: true,
+        isCoachingMessage: false,
+      });
+      await newMessageNotShow2.save();
+      const res = await request(patientApp)
+        .get(`/getPatientMessages/${patient?._id}`)
+        .set('Authorization', `Bearer ${tokenObject.token[0]}`);
+
+      expect(res.statusCode).toBe(200);
+      const messages = res.body;
+      expect(messages.length).toBe(1);
+      expect(messages[0]?.sender).toBe('COACH');
+      expect(messages[0]?.isCoachingMessage).toBe(true);
+    });
+  });
+} else {
+  it('is not development', () => {
+    expect(1).toBeTruthy();
+  });
+}


### PR DESCRIPTION
purpose:
- Add general number to `/getPatientMessages/:patientID` so the coach only sees relevant messages.


Trello:
- https://trello.com/c/KWHti26s/87-coach-phone-line-add-new-twilio-phone-number-to-website

Tests:
- Patient api routes work as intended
   -   ✓ /getPatientMessages/:patientID gets messages with isGeneralNumber 