### PR TITLE
Fix/send message only uses patient

### DIFF
--- a/src/routes/twilio/twilio.api.ts
+++ b/src/routes/twilio/twilio.api.ts
@@ -1,9 +1,8 @@
 import express from 'express';
 import bodyParser from 'body-parser';
 import twilio from 'twilio';
-import { ObjectId } from 'mongodb';
 import auth from '../../middleware/auth';
-import { PatientForPhoneNumber } from '../../models/patient.model';
+import { Patient, PatientForPhoneNumber } from '../../models/patient.model';
 import { parseInboundPatientMessage } from '../../domain/message_parsing';
 import { responseForParsedMessage } from '../../domain/glucose_reading_responses';
 import { Outcome } from '../../models/outcome.model';
@@ -144,14 +143,13 @@ export const manageIncomingMessages = async (
 };
 
 router.post('/sendMessage', auth, async (req, res) => {
-  const recept = req.body.to;
-  const patientID = new ObjectId(req.body.patientID);
+  const patient = await Patient.findById(req.body.patientID);
   const date = new Date();
   const content = req.body.message;
   const outgoingMessage = new Message({
     sent: false,
-    phoneNumber: recept,
-    patientID,
+    phoneNumber: patient?.phoneNumber,
+    patientID: patient?._id,
     message: content,
     sender: 'COACH',
     date,

--- a/src/routes/twilio/twilio.integration.test.ts
+++ b/src/routes/twilio/twilio.integration.test.ts
@@ -28,6 +28,8 @@ if (process.env.NODE_ENV === 'development') {
 
   describe('Twilio api integration properly handles messages', () => {
     it('sendMessage route saves message with sender COACH and coaching number ', async () => {
+      await createPatient('0123456789');
+      const patient = await Patient.findOne({ phoneNumber: '0123456789' });
       const res = await request(twilioApp)
         .post('/sendMessage')
         .set('Authorization', `Bearer ${tokenObject.token[0]}`)
@@ -35,7 +37,7 @@ if (process.env.NODE_ENV === 'development') {
         .send({
           message: 'Test message',
           to: 'test number',
-          patientID: '60aebf123fbd20eba237244e',
+          patientID: `${patient?._id}`,
         });
       expect(res.statusCode).toBe(200);
       const message = await Message.findOne();


### PR DESCRIPTION
Purpose
- Fix issue where sendMessages could take a different phone number and patientID. Now they only use a patientID and gets the number from there.

Trello:
- https://trello.com/c/iAsES7n2/113-in-sendmessage-there-is-a-bug-where-you-could-send-a-different-phone-number-to-a-patient-id

Tests:
- Patient api routes work as intended
   -   ✓ sendMessage route saves message with sender COACH and coaching number