### PR TITLE
Add Modify patient outreach manually

### DIFF
--- a/src/background_jobs/cronSchedules.ts
+++ b/src/background_jobs/cronSchedules.ts
@@ -1,4 +1,8 @@
-import { dailyMidnightMessages, weeklyReport } from './utils';
+import {
+  dailyMidnightMessages,
+  weeklyReport,
+  outreachNoResponseSendNextMessage,
+} from './utils';
 
 const cron = require('node-cron');
 
@@ -11,6 +15,11 @@ const runCronSchedules = () => {
 
   // Send report every monday at 11 AM. PST.
   cron.schedule('0 11 * * *', () => weeklyReport(), {
+    scheduled: true,
+    timezone: 'America/Los_Angeles',
+  });
+
+  cron.schedule('0 18 * * *', () => outreachNoResponseSendNextMessage(), {
     scheduled: true,
     timezone: 'America/Los_Angeles',
   });

--- a/src/background_jobs/utils.integration.test.ts
+++ b/src/background_jobs/utils.integration.test.ts
@@ -1,0 +1,51 @@
+import {
+  connectDatabase,
+  closeDatabase,
+  clearDatabase,
+  createPatient,
+} from '../../test/db';
+import { Message } from '../models/message.model';
+import { outreachNoResponseSendNextMessage } from './utils';
+
+if (process.env.NODE_ENV === 'development') {
+  beforeAll(async () => {
+    await connectDatabase();
+  });
+  beforeEach(async () => clearDatabase());
+  afterAll(() => closeDatabase());
+
+  describe('Outreach sends new messages round after one day of inactivity by the user', () => {
+    it('Outreach sends "MORE" Messages after 24 hours of inactivity by the user', async () => {
+      const yesterday = new Date();
+      yesterday.setHours(yesterday.getHours() - 25);
+      await createPatient('1112223334', {
+        outreach: true,
+        yes: false,
+        complete: false,
+        lastMessageSent: '1',
+        lastDate: yesterday,
+      });
+      await outreachNoResponseSendNextMessage();
+      const messages = await Message.find();
+      expect(messages.length).toBe(5);
+    });
+    it('Outreach sends "YES" Messages after 72 hours of inactivity by the user or 24 after last "MORE" message', async () => {
+      const yesterday = new Date();
+      yesterday.setHours(yesterday.getHours() - 25);
+      await createPatient('1112223334', {
+        outreach: true,
+        yes: false,
+        complete: false,
+        lastMessageSent: '3',
+        lastDate: yesterday,
+      });
+      await outreachNoResponseSendNextMessage();
+      const messages = await Message.find();
+      expect(messages.length).toBe(1);
+    });
+  });
+} else {
+  it('is not development', () => {
+    expect(1).toBeTruthy();
+  });
+}

--- a/src/background_jobs/utils.ts
+++ b/src/background_jobs/utils.ts
@@ -1,10 +1,10 @@
-/* eslint-disable no-console */
 import { ObjectId } from 'mongodb';
 import { Message } from '../models/message.model';
 import { MessageTemplate } from '../models/messageTemplate.model';
 import { IPatient, Patient } from '../models/patient.model';
 import { Outcome, IOutcome } from '../models/outcome.model';
 import { Schedule } from '../models/schedule.model';
+import outreachMessage from '../routes/outreach/outreachResponses';
 
 interface IweekRecords {
   [char: string]: number;
@@ -298,4 +298,22 @@ export const weeklyReport = async () => {
       sendOutcomesToPatients();
     }
   }
+};
+
+export const outreachNoResponseSendNextMessage = async () => {
+  const patients = await Patient.find({
+    'outreach.outreach': true,
+    enabled: true,
+    'outreach.complete': false,
+    'outreach.yes': false,
+  });
+  const yesterday = new Date();
+  yesterday.setHours(yesterday.getHours() - 23);
+  const patientPromises = patients.map(async (patient) => {
+    if (patient.outreach.lastDate < yesterday) {
+      await outreachMessage(patient);
+    }
+  });
+
+  await Promise.all(patientPromises);
 };

--- a/src/models/patient.model.ts
+++ b/src/models/patient.model.ts
@@ -20,6 +20,14 @@ interface IPatient extends mongoose.Document {
     },
   ];
   enabled: boolean;
+  clinic: string;
+  outreach: {
+    outreach: boolean;
+    yes: boolean;
+    complete: boolean;
+    lastMessageSent: string;
+    lastDate: Date;
+  };
 }
 
 const PatientSchema = new Schema({
@@ -39,6 +47,14 @@ const PatientSchema = new Schema({
     },
   ],
   enabled: { type: Boolean, required: true },
+  clinic: { type: String, required: true, default: 'CoachMe' },
+  outreach: {
+    outreach: { type: Boolean, required: true, default: false },
+    yes: { type: Boolean, required: true, default: false },
+    complete: { type: Boolean, required: true, default: false },
+    lastMessageSent: { type: String, required: true, default: '0' },
+    lastDate: { type: Date, required: true, default: new Date() },
+  },
 });
 
 const Patient = mongoose.model<IPatient>('Patient', PatientSchema);

--- a/src/routes/outreach/defaultResponses.ts
+++ b/src/routes/outreach/defaultResponses.ts
@@ -1,0 +1,82 @@
+const DefaultResponses = {
+  zero: {
+    english: (coach: string, name: string, clinic: string) => {
+      return [
+        `Hi ${name}, your team at ${clinic} 🏥 referred you to join the Healthy At Home Program. This is ${coach} and I can tell you more.`,
+        'Diabetes is overwhelming. It can keep you from the long, worry-free life you deserve.',
+        'You’re not alone 🤝 Healthy at Home is a FREE 12-week diabetes coaching program on your phone 📱',
+        'Want to join for FREE? Respond YES to get set up with your diabetes coach or MORE to learn more.',
+      ];
+    },
+    spanish: (coach: string, name: string, clinic: string) => {
+      return [
+        `Hola, ${name} 😊, su equipo de salud de la Clínica ${clinic} le refirió para el programa Saludable en Casa. ¡Soy ${coach}, y me gustaría contarle más!`,
+        'Vivir con Diabetes es agobiante. Le hace difícil tener la vida saludable, y sin-cuidados que merece.',
+        'No está solo 🤝 . Saludable en Casa es un programa GRATIS de 12 semanas de coaching o consejería de diabetes, en su teléfono.',
+        '¿Le gustaría unirse? Es GRATIS. Conteste SI para unirle a su coach o consejero de diabetes, o ponga MAS para aprender más 😊.',
+      ];
+    },
+  },
+  one: {
+    english: () => {
+      return [
+        'Great! We’ve helped people like you manage their diabetes at home. See for yourself:',
+        'https://images.squarespace-cdn.com/content/v1/5ce04d00b68cbf00010e0c76/1600802045596-CU5OJLB15MZJ7RHA9JDH/ke17ZwdGBToddI8pDm48kEpT_Wb2Q40Qb6WVkh_pUN4UqsxRUqqbr1mOJYKfIPR7LoDQ9mXPOjoJoqy81S2I8N_N4V1vUb5AoIIIbLZhVYy7Mythp_T-mtop-vrsUOmeInPi9iDjx9w8K4ZfjXt2duPVlUW5KossE0diiPzOT_7_ZXpOrcaDhMW_HAe3F34eCjLISwBs8eEdxAxTptZAUg/4.png?format=2500w',
+        'https://images.squarespace-cdn.com/content/v1/5ce04d00b68cbf00010e0c76/1620158314094-I08MPXQHBBDBPXK5XQ9S/ke17ZwdGBToddI8pDm48kEpT_Wb2Q40Qb6WVkh_pUN4UqsxRUqqbr1mOJYKfIPR7LoDQ9mXPOjoJoqy81S2I8N_N4V1vUb5AoIIIbLZhVYy7Mythp_T-mtop-vrsUOmeInPi9iDjx9w8K4ZfjXt2duPVlUW5KossE0diiPzOT_7_ZXpOrcaDhMW_HAe3F34eCjLISwBs8eEdxAxTptZAUg/5.png?format=1500w',
+        `Here’s how it works
+        1. We call you to tell you more
+        2. Schedule a visit
+        3. Start feeling great!
+        `,
+        'Ready to start? Respond YES to get set up with your diabetes coach or MORE to learn more',
+      ];
+    },
+    spanish: () => {
+      return [
+        'Bien! Hemos ayudado a mucha gente como usted a mejorar y manejar su diabetes en casa, por telefono. Vealo por usted mismo:',
+        'https://slack-imgs.com/?c=1&o1=ro&url=https%3A%2F%2Fdocument-export.canva.com%2F_iu3o%2FDAEg0W_iu3o%2F3%2Fthumbnail%2F0001-2570826370.png%3FX-Amz-Algorithm%3DAWS4-HMAC-SHA256%26X-Amz-Credential%3DAKIAQYCGKMUHWDTJW6UD%252F20210608%252Fus-east-1%252Fs3%252Faws4_request%26X-Amz-Date%3D20210608T165537Z%26X-Amz-Expires%3D6830%26X-Amz-Signature%3Da09641b0941a0dac86c772cf4d5a97b30cb2842183fb2c7fa2d3726cf41dce5b%26X-Amz-SignedHeaders%3Dhost%26response-expires%3DTue%252C%252008%2520Jun%25202021%252018%253A49%253A27%2520GMT',
+        'https://slack-imgs.com/?c=1&o1=ro&url=https%3A%2F%2Fdocument-export.canva.com%2FpADSs%2FDAEg0VpADSs%2F2%2Fthumbnail%2F0001-2570848775.png%3FX-Amz-Algorithm%3DAWS4-HMAC-SHA256%26X-Amz-Credential%3DAKIAQYCGKMUHWDTJW6UD%252F20210608%252Fus-east-1%252Fs3%252Faws4_request%26X-Amz-Date%3D20210608T020930Z%26X-Amz-Expires%3D59964%26X-Amz-Signature%3D70068d2ae9a73841cc35e796ed269f819436fe1eb7fe51f3ec53f7885903a345%26X-Amz-SignedHeaders%3Dhost%26response-expires%3DTue%252C%252008%2520Jun%25202021%252018%253A48%253A54%2520GMT',
+        `Así es como funciona:
+        1. Le llamamos para contarle más
+        2. Programe una llamada con su coach
+        3. Empiece a sentirse mejor
+        `,
+        '¿Listo para comenzar? Conteste SI para unirle a su coach de diabetes o MÁS para más información.',
+      ];
+    },
+  },
+  two: {
+    english: () => {
+      return [
+        'Wonderful! This valuable program is FREE to you and it’s starting now, so don’t miss out!',
+        'We want you to know you can stop ✋ if you need and it works on any phone 📱.',
+        `Give it a try ✨
+        Respond YES to get set up with your diabetes coach or to learn more.
+        `,
+      ];
+    },
+    spanish: () => {
+      return [
+        '¡Fabuloso! Este programa es GRATUITO y muy valioso. ¡Comience pronto, no pierda la oportunidad!',
+        'Quiero que sepa que funciona desde cualquier teléfono, y puede parar ✋ si lo necesita.',
+        `Pruébelo ✨
+        Responda SI para unirle a su coach de Diabetes, o MÁS para más información.
+        `,
+      ];
+    },
+  },
+  yes: {
+    english: () => {
+      return [
+        'Welcome to Healthy at Home! By joining, you’ve taken step 1️⃣ for your health. 💪',
+      ];
+    },
+    spanish: () => {
+      return [
+        'Bienvenido a Salud en casa! Al unirte has tomado el paso 1️⃣ para tu salud. 💪',
+      ];
+    },
+  },
+};
+
+export default DefaultResponses;

--- a/src/routes/outreach/outreach.integration.test.ts
+++ b/src/routes/outreach/outreach.integration.test.ts
@@ -1,0 +1,48 @@
+import request from 'supertest';
+import express, { response } from 'express';
+import {
+  connectDatabase,
+  closeDatabase,
+  clearDatabase,
+  getTestToken,
+  createPatient,
+} from '../../../test/db';
+import { Patient } from '../../models/patient.model';
+import { Message } from '../../models/message.model';
+import { getResponses } from './outreachResponses';
+
+if (process.env.NODE_ENV === 'development') {
+  const tokenObject = { token: [] };
+  beforeAll(async (done: any) => {
+    await connectDatabase();
+    await getTestToken(tokenObject, done);
+  });
+  beforeEach(async () => clearDatabase());
+  afterAll(() => closeDatabase());
+
+  describe('Twilio api integration properly handles messages', () => {
+    it('outreach responses return defaulr responses appropiately', async () => {
+      await createPatient('0123456789');
+      const patient = await Patient.findOne();
+      let responsesZero = [];
+      let responsesOne = [];
+      let responsesTwo = [];
+      let responsesYes = [];
+      if (patient) {
+        responsesZero = getResponses('english', 'zero', patient);
+        responsesOne = getResponses('english', 'one', patient);
+        responsesTwo = getResponses('english', 'two', patient);
+        responsesYes = getResponses('english', 'yes', patient);
+      }
+
+      expect(responsesZero.length).toBe(4);
+      expect(responsesOne.length).toBe(5);
+      expect(responsesTwo.length).toBe(3);
+      expect(responsesYes.length).toBe(1);
+    });
+  });
+} else {
+  it('is not development', () => {
+    expect(1).toBeTruthy();
+  });
+}

--- a/src/routes/outreach/outreach.test.ts
+++ b/src/routes/outreach/outreach.test.ts
@@ -1,0 +1,29 @@
+import DefaultResponses from './defaultResponses';
+
+describe('Outreach responses tests', () => {
+  it('Gets outreach messages', () => {
+    const responseZero = DefaultResponses.zero.spanish(
+      'Michael',
+      'Bryant',
+      'NBA',
+    );
+
+    expect(responseZero[0].includes('Michael')).toBeTruthy();
+    expect(responseZero.length).toBe(4);
+
+    const responseOne = DefaultResponses.one.english();
+
+    expect(responseOne[1].includes('https')).toBeTruthy();
+    expect(responseOne.length).toBe(5);
+
+    const responseTwo = DefaultResponses.two.english();
+
+    expect(responseTwo[2].includes('Give it a try')).toBeTruthy();
+    expect(responseTwo.length).toBe(3);
+
+    const responseYes = DefaultResponses.yes.english();
+
+    expect(responseYes[0].includes('Welcome')).toBeTruthy();
+    expect(responseYes.length).toBe(1);
+  });
+});

--- a/src/routes/outreach/outreachResponses.ts
+++ b/src/routes/outreach/outreachResponses.ts
@@ -1,0 +1,202 @@
+import { ObjectId } from 'mongodb';
+import { Message } from '../../models/message.model';
+import { Patient, IPatient } from '../../models/patient.model';
+import DefaultResponses from './defaultResponses';
+
+type SupportedLanguage = 'english' | 'spanish';
+
+const sendMessageMinutesFromNow = async (
+  minutes: number,
+  patient: IPatient,
+  message: string,
+) => {
+  const todayPlusMinutes = new Date();
+  todayPlusMinutes.setMinutes(todayPlusMinutes.getMinutes() + minutes);
+  const newMessage = new Message({
+    sent: false,
+    phoneNumber: patient.phoneNumber,
+    patientID: new ObjectId(patient._id),
+    message,
+    sender: 'OUTREACH',
+    date: todayPlusMinutes,
+    isCoachingMessage: true,
+  });
+
+  await newMessage.save();
+};
+
+const responseLanguage = (language?: string): SupportedLanguage => {
+  if (!language) {
+    return 'english';
+  }
+  const cleanLanguage = language.toLowerCase();
+
+  if (cleanLanguage === 'english' || cleanLanguage === 'spanish') {
+    return cleanLanguage;
+  }
+
+  return 'english';
+};
+
+export const getResponses = (
+  language: string,
+  messageIdentifier: string,
+  patient: IPatient,
+) => {
+  let response = [];
+  switch (messageIdentifier) {
+    case 'zero':
+      if (language === 'spanish') {
+        response = DefaultResponses.zero.spanish(
+          patient.coachName,
+          patient.firstName,
+          patient.clinic,
+        );
+      } else {
+        response = DefaultResponses.zero.english(
+          patient.coachName,
+          patient.firstName,
+          patient.clinic,
+        );
+      }
+      break;
+    case 'one':
+      if (language === 'spanish') {
+        response = DefaultResponses.one.spanish();
+      } else {
+        response = DefaultResponses.one.english();
+      }
+      break;
+    case 'two':
+      if (language === 'spanish') {
+        response = DefaultResponses.two.spanish();
+      } else {
+        response = DefaultResponses.two.english();
+      }
+      break;
+    case 'yes':
+      if (language === 'spanish') {
+        response = DefaultResponses.yes.spanish();
+      } else {
+        response = DefaultResponses.yes.english();
+      }
+      break;
+    default:
+      return [''];
+  }
+  return response;
+};
+
+const sendFirstOutreachMessages = async (
+  language: string,
+  patient: IPatient,
+) => {
+  const response = getResponses(language, 'zero', patient);
+
+  await sendMessageMinutesFromNow(1, patient, response[0]);
+  await sendMessageMinutesFromNow(2, patient, response[1]);
+  await sendMessageMinutesFromNow(3, patient, response[2]);
+  await sendMessageMinutesFromNow(4, patient, response[3]);
+
+  await Patient.findOneAndUpdate(
+    { _id: patient._id },
+    {
+      outreach: {
+        outreach: true,
+        yes: false,
+        complete: false,
+        lastMessageSent: '1',
+        lastDate: new Date(),
+      },
+    },
+  );
+};
+
+const sendSecondOutreachMessages = async (
+  language: string,
+  patient: IPatient,
+) => {
+  const response = getResponses(language, 'one', patient);
+
+  await sendMessageMinutesFromNow(1, patient, response[0]);
+  await sendMessageMinutesFromNow(2, patient, response[1]);
+  await sendMessageMinutesFromNow(3, patient, response[2]);
+  await sendMessageMinutesFromNow(4, patient, response[3]);
+  await sendMessageMinutesFromNow(5, patient, response[4]);
+
+  await Patient.findOneAndUpdate(
+    { _id: patient._id },
+    {
+      outreach: {
+        outreach: true,
+        yes: false,
+        complete: false,
+        lastMessageSent: '2',
+        lastDate: new Date(),
+      },
+    },
+  );
+};
+
+const sendThirdOutreachMessages = async (
+  language: string,
+  patient: IPatient,
+) => {
+  const response = getResponses(language, 'two', patient);
+
+  await sendMessageMinutesFromNow(1, patient, response[0]);
+  await sendMessageMinutesFromNow(2, patient, response[1]);
+  await sendMessageMinutesFromNow(3, patient, response[2]);
+
+  await Patient.findOneAndUpdate(
+    { _id: patient._id },
+    {
+      outreach: {
+        outreach: true,
+        yes: false,
+        complete: false,
+        lastMessageSent: '3',
+        lastDate: new Date(),
+      },
+    },
+  );
+};
+
+const sendYESOutreachMessages = async (language: string, patient: IPatient) => {
+  const response = getResponses(language, 'yes', patient);
+
+  await sendMessageMinutesFromNow(1, patient, response[0]);
+
+  await Patient.findOneAndUpdate(
+    { _id: patient._id },
+    {
+      outreach: {
+        outreach: true,
+        yes: true,
+        complete: false,
+        lastMessageSent: 'yes',
+        lastDate: new Date(),
+      },
+    },
+  );
+};
+
+const outreachMessage = async (
+  patient: IPatient,
+  yesMessage: boolean = false,
+): Promise<string[]> => {
+  const language = responseLanguage(patient.language);
+  if (patient.outreach.lastMessageSent === '0' && !yesMessage) {
+    await sendFirstOutreachMessages(language, patient);
+  } else if (patient.outreach.lastMessageSent === '1' && !yesMessage) {
+    await sendSecondOutreachMessages(language, patient);
+  } else if (patient.outreach.lastMessageSent === '2' && !yesMessage) {
+    await sendThirdOutreachMessages(language, patient);
+  } else if (yesMessage || patient.outreach.lastMessageSent === '3') {
+    await sendYESOutreachMessages(language, patient);
+  }
+
+  return [''];
+};
+
+export default outreachMessage;

--- a/src/routes/patient.api.integration.test.ts
+++ b/src/routes/patient.api.integration.test.ts
@@ -7,11 +7,12 @@ import {
   getTestToken,
   createPatient,
 } from '../../test/db';
+import patientRouter from './patient.api';
 import { Patient } from '../models/patient.model';
 import { Message } from '../models/message.model';
-import patientRouter from './patient.api';
 
 const patientApp = express();
+
 patientApp.use(express.json());
 patientApp.use(express.urlencoded({ extended: false }));
 patientApp.use('/', patientRouter);
@@ -25,7 +26,30 @@ if (process.env.NODE_ENV === 'development') {
   beforeEach(async () => clearDatabase());
   afterAll(() => closeDatabase());
 
-  describe('Patient api routes work as intended', () => {
+  describe('Patient works as intended', () => {
+    it('patient outreach is updated when an /updateOureach request is received', async () => {
+      await createPatient('1123412312');
+      const patient = await Patient.findOne({ phoneNumber: '1123412312' });
+      const res = await request(patientApp)
+        .post('/updateOutreach')
+        .set('Authorization', `Bearer ${tokenObject.token[0]}`)
+        .send({
+          patientID: patient?._id,
+          outreach: {
+            outreach: true,
+            yes: false,
+            complete: false,
+            lastMessageSent: '0',
+            lastDate: new Date(),
+          },
+        })
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json');
+      expect(res.statusCode).toBe(200);
+      const modifiedPatient = await Patient.findOne();
+      expect(modifiedPatient?.outreach.outreach).toBeTruthy();
+      expect(modifiedPatient?.outreach.lastMessageSent).toBe('0');
+    });
     it('getPatientMessages/:patientID route gets coaching messages only', async () => {
       await createPatient('1114446668');
       const patient = await Patient.findOne();

--- a/src/routes/patient.api.ts
+++ b/src/routes/patient.api.ts
@@ -111,7 +111,6 @@ router.post('/add', auth, async (req, res) => {
   res.status(200).json({
     success: true,
   });
-  return;
 });
 
 router.put('/increaseResponseCount/:id', auth, (req, res) => {
@@ -204,6 +203,30 @@ router.post('/status', auth, (req, res) => {
       return res.status(200).json('Patiet Status Changed!');
     })
     .catch((err) => errorHandler(res, err.message));
+});
+
+router.post('/updateOutreach', auth, async (req, res) => {
+  const { patientID } = req.body;
+  const { outreach } = req.body;
+  const oldPatient = await Patient.findById(new ObjectId(patientID));
+  if (!oldPatient?.outreach.outreach && outreach.outreach) {
+    outreach.lastMessageSent = '0';
+    outreach.lastDate = new Date();
+  }
+  try {
+    const patient = await Patient.findByIdAndUpdate(
+      new ObjectId(patientID),
+      {
+        outreach,
+      },
+      { new: true },
+    );
+    return res.status(200).json(patient);
+  } catch (e) {
+    const err = e as Error;
+    errorHandler(res, err?.message);
+  }
+  return res.status(200).json('Patient could not be updated');
 });
 
 export default router;

--- a/src/routes/patient.api.ts
+++ b/src/routes/patient.api.ts
@@ -4,6 +4,7 @@ import { Patient, PatientForPhoneNumber } from '../models/patient.model';
 import auth from '../middleware/auth';
 import errorHandler from './error';
 import { Message } from '../models/message.model';
+import outreachMessage from './outreach/outreachResponses';
 
 const { ObjectId } = require('mongoose').Types;
 
@@ -87,12 +88,30 @@ router.post('/add', auth, async (req, res) => {
     coachName: req.body.coachName,
     enabled: req.body.isEnabled,
     prefTime: hours * 60 + mins,
+    clinic: req.body.clinic,
+    outreach: {
+      outreach: req.body.outreach.outreach,
+      complete: req.body.outreach.complete,
+      yes: req.body.outreach.yes,
+      lastMessageSent: req.body.outreach.lastMessageSent,
+      lastDate: req.body.outreach.lastDate,
+    },
   });
-  return newPatient.save().then(() => {
-    res.status(200).json({
-      success: true,
-    });
+  await newPatient.save();
+
+  const patient = await PatientForPhoneNumber(req.body.phoneNumber);
+  if (
+    patient?.outreach.outreach &&
+    patient?.enabled &&
+    !patient?.outreach.complete
+  ) {
+    await outreachMessage(patient);
+  }
+
+  res.status(200).json({
+    success: true,
   });
+  return;
 });
 
 router.put('/increaseResponseCount/:id', auth, (req, res) => {

--- a/src/routes/twilio/twilio.api.ts
+++ b/src/routes/twilio/twilio.api.ts
@@ -3,12 +3,13 @@ import bodyParser from 'body-parser';
 import twilio from 'twilio';
 import { ObjectId } from 'mongodb';
 import auth from '../../middleware/auth';
-import { PatientForPhoneNumber } from '../../models/patient.model';
+import { IPatient, PatientForPhoneNumber } from '../../models/patient.model';
 import { parseInboundPatientMessage } from '../../domain/message_parsing';
 import { responseForParsedMessage } from '../../domain/glucose_reading_responses';
 import { Outcome } from '../../models/outcome.model';
 import { Message } from '../../models/message.model';
 import errorHandler from '../error';
+import outreachMessage from '../outreach/outreachResponses';
 
 const router = express.Router();
 router.use(bodyParser.urlencoded({ extended: true }));
@@ -85,6 +86,19 @@ export const createNewOutcome = async ({
   }
 };
 
+export const parseOutreachMessage = async (
+  message: string,
+  patient: IPatient,
+) => {
+  if (message.includes('YES')) {
+    await outreachMessage(patient, true);
+  }
+
+  if (message.includes('MORE')) {
+    await outreachMessage(patient);
+  }
+};
+
 export const manageIncomingMessages = async (
   req: any,
   res: any,
@@ -111,6 +125,9 @@ export const manageIncomingMessages = async (
   });
 
   if (isCoachingMessage) {
+    if (patient.outreach.outreach && !patient.outreach.yes) {
+      await parseOutreachMessage(inboundMessage, patient);
+    }
     res.writeHead(200, { 'Content-Type': 'text/xml' });
     res.end(incomingMessage?.sent.toString());
     return;

--- a/src/utils/scheduling.ts
+++ b/src/utils/scheduling.ts
@@ -36,9 +36,10 @@ export const getTwilioNumber = (isCoachingMessage: boolean) => {
 const sendMessage = async (msg: IMessage) => {
   const twilioNumber = getTwilioNumber(msg.isCoachingMessage);
   twilio.messages.create({
-    body: msg.message,
+    body: msg.message.includes('https://') ? '' : msg.message,
     from: twilioNumber,
     to: msg.phoneNumber,
+    mediaUrl: [msg.message.includes('https://') ? msg.message : ''],
   });
 
   await Message.findOneAndUpdate(

--- a/test/db.ts
+++ b/test/db.ts
@@ -80,7 +80,10 @@ export const waitJest = async (waitTime: number) => {
   jest.useFakeTimers();
 };
 
-export const createPatient = async (phoneNumber: string) => {
+export const createPatient = async (
+  phoneNumber: string,
+  outreach: object = {},
+) => {
   const patient = new Patient({
     firstName: 'jest',
     lastName: 'jester',
@@ -93,6 +96,7 @@ export const createPatient = async (phoneNumber: string) => {
     responseCount: 0,
     reports: [],
     enabled: true,
+    outreach,
   });
   await patient.save();
 };


### PR DESCRIPTION
Purpose
- Add the ability to modify a patient's outreach status

Trello:
- https://trello.com/c/09qzuGbU/102-allow-coaches-to-change-outreach-status-manually

Tests:
- ✓ patient outreach is updated when an /updateOureach request is received