### PR TITLE
Add schedules to patient model

### DIFF
--- a/src/models/patient.model.ts
+++ b/src/models/patient.model.ts
@@ -28,6 +28,7 @@ interface IPatient extends mongoose.Document {
     lastMessageSent: string;
     lastDate: Date;
   };
+  schedules: any[];
 }
 
 const PatientSchema = new Schema({
@@ -55,6 +56,7 @@ const PatientSchema = new Schema({
     lastMessageSent: { type: String, required: true, default: '0' },
     lastDate: { type: Date, required: true, default: new Date() },
   },
+  schedules: { type: Array, required: false, default: [] }
 });
 
 const Patient = mongoose.model<IPatient>('Patient', PatientSchema);


### PR DESCRIPTION
Purpose
- Allow coaches to see the outreach status of a patient

Trello:
- https://trello.com/c/aqqEQwet/80-appointments-coaches-can-see-a-table-with-all-their-upcoming-appointments-sorted-soonest-to-not-soon