### PR TITLE
Add cron job for sending nudges

### DIFF
--- a/src/background_jobs/cronSchedules.ts
+++ b/src/background_jobs/cronSchedules.ts
@@ -1,4 +1,4 @@
-import { dailyMidnightMessages, weeklyReport } from './utils';
+import { dailyMidnightMessages, weeklyReport, nudgeMessages } from './utils';
 
 const cron = require('node-cron');
 
@@ -11,6 +11,12 @@ const runCronSchedules = () => {
 
   // Send report every monday at 11 AM. PST.
   cron.schedule('0 11 * * *', () => weeklyReport(), {
+    scheduled: true,
+    timezone: 'America/Los_Angeles',
+  });
+
+  // Send nudge every Tue, Thur, and Sat at 1PM PT.
+  cron.schedule('0 13 * * 2,4,6', () => nudgeMessages(), {
     scheduled: true,
     timezone: 'America/Los_Angeles',
   });

--- a/src/background_jobs/cronSchedules.ts
+++ b/src/background_jobs/cronSchedules.ts
@@ -4,19 +4,19 @@ const cron = require('node-cron');
 
 const runCronSchedules = () => {
   // run messages every day at midnight PST
-  cron.schedule('0 0 5 * * *', () => dailyMidnightMessages(), {
+  cron.schedule('0 0 5 * * *', dailyMidnightMessages, {
     scheduled: true,
     timezone: 'America/Los_Angeles',
   });
 
   // Send report every monday at 11 AM. PST.
-  cron.schedule('0 11 * * *', () => weeklyReport(), {
+  cron.schedule('0 11 * * *', weeklyReport, {
     scheduled: true,
     timezone: 'America/Los_Angeles',
   });
 
   // Send nudge every Tue, Thur, and Sat at 1PM PT.
-  cron.schedule('0 13 * * 2,4,6', () => nudgeMessages(), {
+  cron.schedule('0 13 * * 2,4,6', nudgeMessages, {
     scheduled: true,
     timezone: 'America/Los_Angeles',
   });

--- a/src/background_jobs/utils.ts
+++ b/src/background_jobs/utils.ts
@@ -12,7 +12,7 @@ interface IweekRecords {
 }
 
 export const dailyMidnightMessages = async () => {
-  console.log('Running batch of scheduled messages');
+  console.log('Running batch of midnight messages');
   const patients = await Patient.find();
   const MessageTemplates = await MessageTemplate.find({ type: 'Initial' });
   patients.forEach(async (patient) => {
@@ -24,9 +24,9 @@ export const dailyMidnightMessages = async () => {
     const possibleMessages = MESSAGES_BY_LANGUAGE[patient.language];
     const message = sample(possibleMessages)?.text;
 
-    if (possibleMessages.length === 0) {
+    if (!message) {
       console.log(
-        'Unable to find message appropriate for member = ',
+        'Unable to find midnight message appropriate for member = ',
         patient._id,
       );
       return;
@@ -40,12 +40,17 @@ export const dailyMidnightMessages = async () => {
       sender: 'BOT',
       sent: false,
     });
-    await newMessage.save();
+
+    try {
+      await newMessage.save();
+    } catch (err) {
+      console.log(err);
+    }
   });
 };
 
 export const nudgeMessages = async () => {
-  console.log('Running nudge messages');
+  console.log('Running batch of nudge messages');
   const patients = await Patient.find();
   const NUDGES = await MessageTemplate.find({ type: 'Nudge' });
   patients.forEach(async (patient) => {
@@ -57,9 +62,9 @@ export const nudgeMessages = async () => {
     const possibleMessages = NUDGES_BY_LANGUAGE[patient.language];
     const message = sample(possibleMessages)?.text;
 
-    if (possibleMessages.length === 0) {
+    if (!message) {
       console.log(
-        'Unable to find message appropriate for member = ',
+        'Unable to find nudge message appropriate for member = ',
         patient._id,
       );
       return;
@@ -74,7 +79,12 @@ export const nudgeMessages = async () => {
       sent: false,
       isCoachingMessage: true,
     });
-    await newMessage.save();
+
+    try {
+      await newMessage.save();
+    } catch (error) {
+      console.log(error);
+    }
   });
 };
 

--- a/src/background_jobs/utils.ts
+++ b/src/background_jobs/utils.ts
@@ -42,6 +42,39 @@ export const dailyMidnightMessages = async () => {
   });
 };
 
+export const nudgeMessages = async () => {
+  console.log('Running nudge messages');
+  const patients = await Patient.find();
+  const MessageTemplates = await MessageTemplate.find({ type: 'Nudge' });
+  patients.forEach(async (patient) => {
+    if (patient.enabled) {
+      const messages = MessageTemplates.filter(
+        (template) =>
+          template.language.toLowerCase() === patient.language.toLowerCase(),
+      );
+      if (messages.length < 1) {
+        console.log(
+          'Unable to find message appropriate for member = ',
+          patient._id,
+        );
+        return;
+      }
+      const randomVal = Math.floor(Math.random() * messages.length);
+      const message = messages[randomVal].text;
+      const newMessage = new Message({
+        patientID: new ObjectId(patient._id),
+        phoneNumber: patient.phoneNumber,
+        date: new Date(),
+        message,
+        sender: 'BOT',
+        sent: false,
+        isCoachingMessage: true,
+      });
+      await newMessage.save();
+    }
+  });
+};
+
 export const compareOutcomesByDate = (a: IOutcome, b: IOutcome) => {
   if (a.date > b.date) {
     return 1;

--- a/src/background_jobs/utils.ts
+++ b/src/background_jobs/utils.ts
@@ -24,7 +24,7 @@ export const dailyMidnightMessages = async () => {
     const possibleMessages = MESSAGES_BY_LANGUAGE[patient.language];
     const message = sample(possibleMessages)?.text;
 
-    if (possibleMessages.length < 1) {
+    if (possibleMessages.length === 0) {
       console.log(
         'Unable to find message appropriate for member = ',
         patient._id,
@@ -57,7 +57,7 @@ export const nudgeMessages = async () => {
     const possibleMessages = NUDGES_BY_LANGUAGE[patient.language];
     const message = sample(possibleMessages)?.text;
 
-    if (possibleMessages.length < 1) {
+    if (possibleMessages.length === 0) {
       console.log(
         'Unable to find message appropriate for member = ',
         patient._id,


### PR DESCRIPTION
Purpose:

- Automated sending of 'goal nudges' from coach number. Patients should receive a random message from a pre-written messages 3 days a week (Tues, Thurs, and Sat) in the afternoon (1PM PT) if they're active. Nudges are added as a 'message template' type.

Trello:

- https://trello.com/c/u4Kea7sx

Tests:

- Integration test for sending nudge messages mirroring integration test for midnight messages. Noted that this set to falsy for both even though the message is being sent.

Related Refactor for `dailyMidnightMessages` in implementing `nudgeMessages`:

- Use lodash (groupBy) to group messages by language so its easier to get all english language messages for example.
- Use lodash (sample) for random message
- nit: `() => dailyMidnightMessages()` can just be `dailyMidnightMessages()`. 
- nit: Moved to `if (!patient.enabled) { return }` to avoid "indenting" to improve readability
- nit: Moved from `if (messages.length < 1) ` to `if (messages.length === 0)` for clarity

Future Improvements:

- Send only if patient has received the first blood glucose reading
- Nudges could be day specific or message content could change depending on the day
- Stratify message sending based on patient need

This is my first PR here. Let me know if you have any feedback! 👋🏽 
